### PR TITLE
Changed versions of php extension in the provisioning script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -112,7 +112,7 @@ apt-get -q -y  install php7.0-mcrypt
 apt-get -q -y  install php7.0-intl
 apt-get -q -y  install php7.0-mbstring
 apt-get -q -y  install php7.0-zip
-apt-get -q -y  install php7.0-pear
+apt-get -q -y  install php-pear
 apt-get -q -y  install libcurl3-openssl-dev
 pecl install pecl_http
 /etc/init.d/apache2 restart

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,12 +107,12 @@ sed -i "s/\['AllowNoPassword'\] = false;/\['AllowNoPassword'\] = true;/g" /var/w
 echo "########################"
 echo "##### PHP EXTENSIONS ###"
 echo "########################"
-apt-get -q -y  install php-xml
-apt-get -q -y  install php-mcrypt
-apt-get -q -y  install php-intl
-apt-get -q -y  install php-mbstring
-apt-get -q -y  install php-zip
-apt-get -q -y  install php-pear
+apt-get -q -y  install php7.0-xml
+apt-get -q -y  install php7.0-mcrypt
+apt-get -q -y  install php7.0-intl
+apt-get -q -y  install php7.0-mbstring
+apt-get -q -y  install php7.0-zip
+apt-get -q -y  install php7.0-pear
 apt-get -q -y  install libcurl3-openssl-dev
 pecl install pecl_http
 /etc/init.d/apache2 restart


### PR DESCRIPTION
Without specifying the version '7.0' in a package name, some of them were not installed on php 7.0.x. Non-compatible versions were installed instead. Because of that, composer was complaining about missing extensions.